### PR TITLE
add chat endpoint

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -39,11 +39,11 @@ echo "Building image"
 
 docker pull --platform linux/amd64 python:3.8
 docker buildx build --platform linux/amd6 -t $IMAGE .
-docker push $IMAGE:latest
+docker push $IMAGE\:latest
 
 echo "Deploying to Google Cloud Run"
 
-gcloud beta run deploy $CLOUD_RUN_SERVICE --image $IMAGE:latest \
+gcloud beta run deploy $CLOUD_RUN_SERVICE --image $IMAGE\:latest \
 --min-instances=1 --memory 256M --cpu=2 --platform managed --no-traffic --tag=test \
 --service-account=service@stampy-nlp.iam.gserviceaccount.com \
 --update-env-vars=QA_MODEL_URL=$QA_MODEL_URL,RETRIEVER_MODEL_URL=$RETRIEVER_MODEL_URL,LIT_SEARCH_MODEL_URL=$LIT_SEARCH_MODEL_URL \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "Flask",
     "google-cloud-storage",
     "gunicorn",
+    "openai",
     "pandas",
     "pinecone-client",
     "python-dotenv",

--- a/setup.sh
+++ b/setup.sh
@@ -5,9 +5,9 @@ echo
 echo "Setting up Dev Env..."
 if [ -d venv ]; then
     echo '-> Using existing virtualenv'
-elif [ `whereis -bq python3.8` ]; then
+elif [ `whereis -b python3.8` ]; then
     virtualenv -p python3.8 venv
-elif [ `whereis -bq python3.9` ]; then
+elif [ `whereis -b python3.9` ]; then
     virtualenv -p python3.9 venv
 else
     echo 'No Python 3.8 or 3.9 found - aborting'  >> /dev/stderr
@@ -26,13 +26,19 @@ if [ ! -f .env ]; then
     echo "Create a Pinecode token (https://app.pinecone.io), but make sure the environment is 'us-west1-gcp'"
     read -p "Pinecode API key: " PINECONE_TOKEN
 
+    echo
+    echo "Create an OpenAI secret key (https://platform.openai.com/account/api-keys)"
+    read -p "OpenAI API key: " OPENAI_TOKEN
+
     cat << EOT > .env
 CODA_TOKEN=$CODA_TOKEN
 PINECONE_API_KEY=$PINECONE_TOKEN
+OPENAI_API_KEY=$OPENAI_TOKEN
 
-QA_MODEL_URL=http://0.0.0.0:8125
-RETRIEVER_MODEL_URL=http://0.0.0.0:8124
-LIT_SEARCH_MODEL_URL=http://0.0.0.0:8126
+GCLOUD_PROJECT_ID=t6p37v2uia
+QA_MODEL_URL=https://qa-model-$GCLOUD_PROJECT_ID-uw.a.run.app
+RETRIEVER_MODEL_URL=https://retriever-model-$GCLOUD_PROJECT_ID-uw.a.run.app
+LIT_SEARCH_MODEL_URL=https://lit-search-model-$GCLOUD_PROJECT_ID-uw.a.run.app
 EOT
     echo "-> Tokens written to ./.env"
 fi

--- a/src/stampy_nlp/faq_titles.py
+++ b/src/stampy_nlp/faq_titles.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 COUNT: int = 3
 MAX_DUPLICATES:int = 100
-MODEL_ID: str = 'multi-qa-mpnet-base-cos-v1'
 delete_all: bool = False
 
 

--- a/src/stampy_nlp/routes.py
+++ b/src/stampy_nlp/routes.py
@@ -5,9 +5,9 @@ from flask import render_template, jsonify, request, Blueprint
 from stampy_nlp.settings import AUTH_PASSWORD
 from stampy_nlp.utilities.pinecone_utils import DEFAULT_TOPK
 from stampy_nlp.faq_titles import encode_faq_titles
-from stampy_nlp.search import semantic_search, extract_qa, lit_search
+from stampy_nlp.search import semantic_search, lit_search, extract_qa, generate_qa
 
-logger = logging.getLogger(__name__, )
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 DEFAULT_QUERY: str = 'What is AI Safety?'
@@ -98,7 +98,7 @@ def search_api():
 
 @api.route('/duplicates', methods=['GET'])
 def duplicates_api():
-    logger.debug('api_duplicates()')
+    logger.debug('duplicates_api()')
     return jsonify(show_duplicates())
 
 
@@ -108,6 +108,16 @@ def literature_api():
     query = request.args.get("query", DEFAULT_QUERY)
     top_k = as_int("top", DEFAULT_TOPK)
     return jsonify(lit_search(query, top_k=top_k))
+
+
+@api.route('/chat', methods=['GET', 'POST'])
+def chat_api():
+    logger.debug('chat_api()')
+    if request.method == "POST":
+        query = request.form.query
+    elif request.method == "GET":
+        query = request.args.get("query", DEFAULT_QUERY)
+    return jsonify(generate_qa(query))
 
 
 @api.route('/extract', methods=['GET', 'POST'])

--- a/src/stampy_nlp/settings.py
+++ b/src/stampy_nlp/settings.py
@@ -7,6 +7,7 @@ load_dotenv()
 
 CODA_TOKEN: str = os.getenv('CODA_TOKEN')
 PINECONE_API_KEY: str = os.getenv('PINECONE_API_KEY')
+OPENAI_API_KEY: str = os.getenv('OPENAI_API_KEY')
 
 STAMPY_BUCKET: str = os.getenv('STAMPY_BUCKET', 'stampy-nlp-resources')
 DUPLICATES_FILENAME: str = os.getenv('DUPLICATES_FILENAME', 'stampy-duplicates.json')
@@ -21,6 +22,7 @@ def check_required_vars():
     required_vars = {
         'CODA_TOKEN': CODA_TOKEN,
         'PINECONE_API_KEY': PINECONE_API_KEY,
+        'OPENAI_API_KEY': OPENAI_API_KEY,
     }
     missing_vars = [var_name for var_name, val in required_vars.items() if not val]
     if missing_vars:
@@ -33,3 +35,7 @@ def get_coda_token():
 
 def get_pinecode_key():
     return PINECONE_API_KEY
+
+
+def get_openai_key():
+    return OPENAI_API_KEY

--- a/src/stampy_nlp/utilities/coda_utils.py
+++ b/src/stampy_nlp/utilities/coda_utils.py
@@ -18,7 +18,7 @@ EXCLUDE_STATUS: List[str] = ['Duplicate', 'Marked for deletion']
 
 def get_df_data():
     """Fetches questions from Coda and returns a pandas dataframe for processing"""
-    logging.debug(f"get_df_data()")
+    logging.debug("get_df_data()")
 
     url: str = f'https://coda.io/apis/v1/docs/{CODA_DOC_ID}/tables/{TABLE_ID}/rows'
     headers: object = {'Authorization': f'Bearer {get_coda_token()}'}

--- a/src/stampy_nlp/utilities/openai_utils.py
+++ b/src/stampy_nlp/utilities/openai_utils.py
@@ -1,0 +1,46 @@
+"""OpenAI Functions
+
+Call OpenAI ChatGPT API.
+"""
+import openai
+import logging
+from stampy_nlp.settings import get_openai_key
+
+
+MODEL = 'gpt-3.5-turbo'
+SYSTEM_MSG = "You are a patient and helpful AI safety research assistant. You use a tone that is technical and scientific."
+PREFIX_MSG = """Given the following links to resources, extracted parts of longer documents, and a question at the end, create a final answer using the links and content provided. 
+    If you don't know the answer, just say that you don't know. Don't try to make up an answer."""
+CONSTRAIN_MSG = "Do not add information from outside content."
+openai.api_key = get_openai_key()
+
+
+def generate_answer(query: str, sources: str, past_user_msgs=[], past_generated_msgs=[], max_history: int = 0, constrain: bool = False):
+    logging.debug("generate_answer()")
+
+    messages = [{"role": "system", "content": SYSTEM_MSG}]
+    num_history = min(len(past_user_msgs), max_history)
+    for i in range(-1 * num_history, 0, 1):
+        messages.append({"role": "user", "content": past_user_msgs[i]})
+        messages.append(
+            {"role": "assistant", "content": past_generated_msgs[i]})
+
+    CONTENT = PREFIX_MSG
+    if constrain:
+        CONTENT += CONSTRAIN_MSG
+    CONTENT += sources
+
+    CONTENT += f"\n\nQUESTION: {query}"
+    CONTENT += "\n\nFINAL ANSWER:"
+
+    # generated_text = sources
+    messages.append({"role": "user", "content": CONTENT})
+    response = openai.ChatCompletion.create(
+        model=MODEL,
+        messages=messages,
+        temperature=0,
+    )
+
+    generated_text = (response['choices'][0]['message']['content'])
+    logging.debug("\n\nmessages %s", messages)
+    return generated_text

--- a/src/stampy_nlp/utilities/pinecone_utils.py
+++ b/src/stampy_nlp/utilities/pinecone_utils.py
@@ -36,7 +36,7 @@ def get_index():
 
 def upload_data(ids, vectors, meta, namespace: str = PINECONE_NAMESPACE, delete_all: bool = False):
     """Upload embeddings to pinecone vector database for faster query"""
-    logging.debug(f"upload_data()")
+    logging.debug("upload_data()")
     index = get_index()
     if delete_all:
         index.delete(delete_all=True, namespace=PINECONE_NAMESPACE)


### PR DESCRIPTION
Exposes the `/chat` endpoint which will return a generated answer from ChatGPT with retrieval augmentation based on ARD sources with semantically similar chunks of text. This can then be called by an UI, Discord bot, etc. 

For the `/chat` route (routes.py), in addition taking `query` it should also accept optional parameters below that match generate_qa (search.py) and generate_answer (openai_utils.py) with default values as specified.

- namespace: str = 'extracted-chunks' # can also be 'all-chunks'
- top_k: int = DEFAULT_TOPK
- max_history: int = 0, 
- constrain: bool = False